### PR TITLE
Fix Legacy Search Tests, add LS option to Riak config script.

### DIFF
--- a/src/CorrugatedIron.Tests.Deprecated/BucketPropertyTests.cs
+++ b/src/CorrugatedIron.Tests.Deprecated/BucketPropertyTests.cs
@@ -6,9 +6,9 @@ using CorrugatedIron.Tests.Extensions;
 using CorrugatedIron.Tests.Live.LiveRiakConnectionTests;
 using NUnit.Framework;
 
-namespace CorrugatedIron.Tests.Live.Deprecated
+namespace CorrugatedIron.Tests.Deprecated
 {
-    [TestFixture()]
+    [TestFixture]
     public class WhenDealingWithBucketProperties : LiveRiakConnectionTestBase
     {
         // use the one node configuration here because we might run the risk

--- a/src/CorrugatedIron.Tests.Deprecated/CorrugatedIron.Tests.Deprecated.csproj
+++ b/src/CorrugatedIron.Tests.Deprecated/CorrugatedIron.Tests.Deprecated.csproj
@@ -37,6 +37,7 @@
     <Compile Include="BucketPropertyTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="RiakPbLegacySearchTests.cs" />
+    <Compile Include="RiakSearchMapReduceInputTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\CorrugatedIron.Tests.Live\CorrugatedIron.Tests.Live.csproj">

--- a/src/CorrugatedIron.Tests.Deprecated/RiakPbLegacySearchTests.cs
+++ b/src/CorrugatedIron.Tests.Deprecated/RiakPbLegacySearchTests.cs
@@ -16,7 +16,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using CorrugatedIron.Extensions;
 using CorrugatedIron.Models;
 using CorrugatedIron.Models.Search;
@@ -73,7 +72,7 @@ namespace CorrugatedIron.Tests.Live.Deprecated
                 Query = new RiakFluentSearch("riak_search_bucket", "name").Search("Alyssa").Build()
             };
 
-            var result = RunSolrQuery(req).WaitUntil(AnyMatchIsFound);
+            var result = Client.RunSolrQuery(req).WaitUntil(SearchTestHelpers.AnyMatchIsFound);
             result.IsSuccess.ShouldBeTrue(result.ErrorMessage);
             result.Value.NumFound.ShouldEqual(1u);
             result.Value.Documents.Count.ShouldEqual(1);
@@ -90,7 +89,7 @@ namespace CorrugatedIron.Tests.Live.Deprecated
             };
 
 
-            var result = RunSolrQuery(req).WaitUntil(TwoMatchesFound);
+            var result = Client.RunSolrQuery(req).WaitUntil(SearchTestHelpers.TwoMatchesFound);
             result.IsSuccess.ShouldBeTrue(result.ErrorMessage);
             result.Value.NumFound.ShouldEqual(2u);
             result.Value.Documents.Count.ShouldEqual(2);
@@ -108,7 +107,7 @@ namespace CorrugatedIron.Tests.Live.Deprecated
                 .And("an")
                 .And("mathematician", t => t.Or("favorites_ablum", "Fame"));
 
-            var result = RunSolrQuery(req).WaitUntil(AnyMatchIsFound);
+            var result = Client.RunSolrQuery(req).WaitUntil(SearchTestHelpers.AnyMatchIsFound);
             result.IsSuccess.ShouldBeTrue(result.ErrorMessage);
             result.Value.NumFound.ShouldEqual(1u);
             result.Value.Documents.Count.ShouldEqual(1);
@@ -134,7 +133,7 @@ namespace CorrugatedIron.Tests.Live.Deprecated
                 .And("an")
                 .And("mathematician", t => t.Or("favorites_ablum", "Fame"));
 
-            var result = RunSolrQuery(req).WaitUntil(AnyMatchIsFound);
+            var result = Client.RunSolrQuery(req).WaitUntil(SearchTestHelpers.AnyMatchIsFound);
 
             result.IsSuccess.ShouldBeTrue(result.ErrorMessage);
             result.Value.NumFound.ShouldEqual(1u);
@@ -144,35 +143,6 @@ namespace CorrugatedIron.Tests.Live.Deprecated
             result.Value.Documents[0].Id.ShouldNotBeNull();
         }
 
-        private Func<RiakResult<RiakSearchResult>> RunSolrQuery(RiakSearchRequest req)
-        {
-            Func<RiakResult<RiakSearchResult>> runSolrQuery =
-                () => Client.Search(req);
-            return runSolrQuery;
-        }
 
-        private static Func<RiakResult<RiakSearchResult>, bool> AnyMatchIsFound
-        {
-            get
-            {
-                Func<RiakResult<RiakSearchResult>, bool> matchIsFound =
-                    result => result.IsSuccess &&
-                              result.Value != null &&
-                              result.Value.NumFound > 0;
-                return matchIsFound;
-            }
-        }
-
-        private static Func<RiakResult<RiakSearchResult>, bool> TwoMatchesFound
-        {
-            get
-            {
-                Func<RiakResult<RiakSearchResult>, bool> twoMatchesFound =
-                    result => result.IsSuccess &&
-                              result.Value != null &&
-                              result.Value.NumFound == 2;
-                return twoMatchesFound;
-            }
-        }
     }
 }

--- a/src/CorrugatedIron.Tests.Deprecated/RiakPbLegacySearchTests.cs
+++ b/src/CorrugatedIron.Tests.Deprecated/RiakPbLegacySearchTests.cs
@@ -48,6 +48,12 @@ namespace CorrugatedIron.Tests.Live.Deprecated
             PrepSearchData();
         }
 
+        [TestFixtureTearDown]
+        public void TearDown()
+        {
+            Client.DeleteBucket(Bucket);
+        }
+
         private void PrepSearchData()
         {
             Func<RiakResult<RiakObject>> put1 = () => Client.Put(new RiakObject(Bucket, RiakSearchKey, RiakSearchDoc.ToRiakString(),
@@ -63,6 +69,7 @@ namespace CorrugatedIron.Tests.Live.Deprecated
             put1Result.IsSuccess.ShouldBeTrue(put1Result.ErrorMessage);
             put2Result.IsSuccess.ShouldBeTrue(put2Result.ErrorMessage);
         }
+
 
         [Test]
         public void SearchingWithSimpleFluentQueryWorksCorrectly()

--- a/src/CorrugatedIron.Tests.Deprecated/RiakSearchMapReduceInputTests.cs
+++ b/src/CorrugatedIron.Tests.Deprecated/RiakSearchMapReduceInputTests.cs
@@ -14,18 +14,19 @@
 // specific language governing permissions and limitations
 // under the License.
 
+using System.Linq;
 using CorrugatedIron.Comms;
 using CorrugatedIron.Models;
 using CorrugatedIron.Models.MapReduce;
 using CorrugatedIron.Models.MapReduce.Inputs;
 using CorrugatedIron.Models.Search;
 using CorrugatedIron.Tests.Extensions;
+using CorrugatedIron.Tests.Live;
 using CorrugatedIron.Tests.Live.Extensions;
 using CorrugatedIron.Util;
 using NUnit.Framework;
-using System.Linq;
 
-namespace CorrugatedIron.Tests.Live
+namespace CorrugatedIron.Tests.Deprecated
 {
     [TestFixture(Ignore = true, IgnoreReason = "Riak Search functionality has been deprecated in favor of Yokozuna/Solr.")]
     public class RiakSearchMapReduceInputTests : RiakMapReduceTests

--- a/src/CorrugatedIron.Tests.Deprecated/RiakSearchMapReduceInputTests.cs
+++ b/src/CorrugatedIron.Tests.Deprecated/RiakSearchMapReduceInputTests.cs
@@ -14,8 +14,10 @@
 // specific language governing permissions and limitations
 // under the License.
 
+using System;
 using System.Linq;
 using CorrugatedIron.Comms;
+using CorrugatedIron.Extensions;
 using CorrugatedIron.Models;
 using CorrugatedIron.Models.MapReduce;
 using CorrugatedIron.Models.MapReduce.Inputs;
@@ -28,74 +30,95 @@ using NUnit.Framework;
 
 namespace CorrugatedIron.Tests.Deprecated
 {
-    [TestFixture(Ignore = true, IgnoreReason = "Riak Search functionality has been deprecated in favor of Yokozuna/Solr.")]
+    [TestFixture]
     public class RiakSearchMapReduceInputTests : RiakMapReduceTests
     {
-        // N.B. You need to install the search hooks on the riak_search_bucket first via `bin/search-cmd install riak_search_bucket`
+        private new const string Bucket = "riak_search_bucket";
         private const string RiakSearchKey = "a.hacker";
         private const string RiakSearchKey2 = "a.public";
         private const string RiakSearchDoc = "{\"name\":\"Alyssa P. Hacker\", \"bio\":\"I'm an engineer, making awesome things.\", \"favorites\":{\"book\":\"The Moon is a Harsh Mistress\",\"album\":\"Magical Mystery Tour\", }}";
         private const string RiakSearchDoc2 = "{\"name\":\"Alan Q. Public\", \"bio\":\"I'm an exciting mathematician\", \"favorites\":{\"book\":\"Prelude to Mathematics\",\"album\":\"The Fame Monster\"}}";
 
-        public RiakSearchMapReduceInputTests ()
-        {
-            Bucket = "riak_search_bucket";
-        }
-        
-        [SetUp]
+        [TestFixtureSetUp]
         public void SetUp() 
         {
             Cluster = new RiakCluster(ClusterConfig, new RiakConnectionFactory());
             Client = Cluster.CreateClient();
-            
+
             var props = Client.GetBucketProperties(Bucket).Value;
             props.SetLegacySearch(true);
             Client.SetBucketProperties(Bucket, props);
+
+            PrepSearchData();
         }
-        
-        [TearDown]
+
+        [TestFixtureTearDown]
         public void TearDown()
         {
             Client.DeleteBucket(Bucket);
         }
+
+        private void PrepSearchData()
+        {
+            Func<RiakResult<RiakObject>> put1 = () => Client.Put(new RiakObject(Bucket, RiakSearchKey, RiakSearchDoc.ToRiakString(),
+                                                      RiakConstants.ContentTypes.ApplicationJson, RiakConstants.CharSets.Utf8));
+
+            var put1Result = put1.WaitUntil();
+
+            Func<RiakResult<RiakObject>> put2 = () => Client.Put(new RiakObject(Bucket, RiakSearchKey2, RiakSearchDoc2.ToRiakString(),
+                                                      RiakConstants.ContentTypes.ApplicationJson, RiakConstants.CharSets.Utf8));
+
+            var put2Result = put2.WaitUntil();
+
+            put1Result.IsSuccess.ShouldBeTrue(put1Result.ErrorMessage);
+            put2Result.IsSuccess.ShouldBeTrue(put2Result.ErrorMessage);
+        }
         
+       
         [Test]
         public void SearchingByNameReturnsTheObjectId()
         {
-            Client.Put(new RiakObject(Bucket, RiakSearchKey, RiakSearchDoc, RiakConstants.ContentTypes.ApplicationJson));
-            Client.Put(new RiakObject(Bucket, RiakSearchKey2, RiakSearchDoc2, RiakConstants.ContentTypes.ApplicationJson));
-
             var mr = new RiakMapReduceQuery()
-                .Inputs(new RiakBucketSearchInput(Bucket, "name:A1*"));
+                .Inputs(new RiakBucketSearchInput(Bucket, "name:Al*"));
 
             var result = Client.MapReduce(mr);
             result.IsSuccess.ShouldBeTrue(result.ErrorMessage);
             
-            var mrResult = result.Value;
-            mrResult.PhaseResults.Count().ShouldEqual(1);
-            
-            mrResult.PhaseResults.ElementAt(0).Values.ShouldNotBeNull();
-            // TODO Add data introspection to test - need to verify the results, after all.
+            var phaseResults = result.Value.PhaseResults.ToList();
+            phaseResults.Count.ShouldEqual(1);
+
+            CheckThatResultContainAllKeys(result);
         }
         
         [Test]
         public void SearchingViaFluentSearchObjectWorks()
         {
-            Client.Put(new RiakObject(Bucket, RiakSearchKey, RiakSearchDoc, RiakConstants.ContentTypes.ApplicationJson));
-            Client.Put(new RiakObject(Bucket, RiakSearchKey2, RiakSearchDoc2, RiakConstants.ContentTypes.ApplicationJson));
-
-            var search = new RiakFluentSearch(Bucket, "name").Search(Token.StartsWith("A1")).Build();
+            var search = new RiakFluentSearch(Bucket, "name").Search(Token.StartsWith("Al")).Build();
             var mr = new RiakMapReduceQuery()
                 .Inputs(new RiakBucketSearchInput(search));
 
             var result = Client.MapReduce(mr);
             result.IsSuccess.ShouldBeTrue(result.ErrorMessage);
-            
-            var mrResult = result.Value;
-            mrResult.PhaseResults.Count().ShouldEqual(1);
-            
-            mrResult.PhaseResults.ElementAt(0).Values.ShouldNotBeNull();
-            // TODO Add data introspection to test - need to verify the results, after all.
+
+            CheckThatResultContainAllKeys(result);
+        }
+
+        private static void CheckThatResultContainAllKeys(RiakResult<RiakMapReduceResult> result)
+        {
+            var phaseResults = result.Value.PhaseResults.ToList();
+            phaseResults.Count.ShouldEqual(1);
+
+            var searchResults = phaseResults[0];
+            searchResults.Values.ShouldNotBeNull();
+            searchResults.Values.Count.ShouldEqual(2);
+
+            foreach (var searchResult in searchResults.Values)
+            {
+                var s = searchResult.FromRiakString();
+                if (!(s.Contains(RiakSearchKey) || s.Contains(RiakSearchKey2)))
+                    Assert.Fail("Results did not contain either \"{0}\" or \"{1}\". \r\nResult was:\"{2}\"", RiakSearchKey,
+                        RiakSearchKey2, s);
+            }
         }
     }
 }

--- a/src/CorrugatedIron.Tests.Live/CorrugatedIron.Tests.Live.csproj
+++ b/src/CorrugatedIron.Tests.Live/CorrugatedIron.Tests.Live.csproj
@@ -59,6 +59,7 @@
     <Compile Include="BucketPropertyTests.cs" />
     <Compile Include="Extensions\IntegrationTestExtensions.cs" />
     <Compile Include="Extensions\IntegrationTestExtensionsTest.cs" />
+    <Compile Include="Extensions\SearchTestHelpers.cs" />
     <Compile Include="GeneralIntegrationTests.cs" />
     <Compile Include="IdleTests.cs" />
     <Compile Include="LiveRiakConnectionTestBase.cs" />
@@ -70,7 +71,6 @@
     <Compile Include="RiakConfigurationTests.cs" />
     <Compile Include="RiakMapReduceTests.cs" />
     <Compile Include="RiakObjectTests.cs" />
-    <Compile Include="RiakSearchMapReduceInputTests.cs" />
     <Compile Include="RiakIndexTests.cs" />
     <Compile Include="Search\TestSearchAdminOperations.cs" />
   </ItemGroup>

--- a/src/CorrugatedIron.Tests.Live/Extensions/SearchTestHelpers.cs
+++ b/src/CorrugatedIron.Tests.Live/Extensions/SearchTestHelpers.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using CorrugatedIron.Models.Search;
+
+namespace CorrugatedIron.Tests.Live.Extensions
+{
+    public static class SearchTestHelpers
+    {
+        public static Func<RiakResult<RiakSearchResult>> RunSolrQuery(this IRiakClient client, RiakSearchRequest req)
+        {
+            Func<RiakResult<RiakSearchResult>> runSolrQuery =
+                () => client.Search(req);
+            return runSolrQuery;
+        }
+
+        public static Func<RiakResult<RiakSearchResult>, bool> AnyMatchIsFound
+        {
+            get
+            {
+                Func<RiakResult<RiakSearchResult>, bool> matchIsFound =
+                    result => result.IsSuccess &&
+                              result.Value != null &&
+                              result.Value.NumFound > 0;
+                return matchIsFound;
+            }
+        }
+
+        public static Func<RiakResult<RiakSearchResult>, bool> TwoMatchesFound
+        {
+            get
+            {
+                Func<RiakResult<RiakSearchResult>, bool> twoMatchesFound =
+                    result => result.IsSuccess &&
+                              result.Value != null &&
+                              result.Value.NumFound == 2;
+                return twoMatchesFound;
+            }
+        }
+    }
+}

--- a/src/CorrugatedIron.Tests.Live/Search/TestSearchOperation.cs
+++ b/src/CorrugatedIron.Tests.Live/Search/TestSearchOperation.cs
@@ -99,8 +99,8 @@ namespace CorrugatedIron.Tests.Live.Search
                     .Search(_randomId + "Alyssa P. Hacker")
                     .Build()
             };
-            
-            var searchResult = RunSolrQuery(req).WaitUntil(AnyMatchIsFound);
+
+            var searchResult = Client.RunSolrQuery(req).WaitUntil(SearchTestHelpers.AnyMatchIsFound);
 
             searchResult.IsSuccess.ShouldBeTrue(searchResult.ErrorMessage);
             searchResult.Value.NumFound.ShouldEqual(1u);
@@ -120,7 +120,7 @@ namespace CorrugatedIron.Tests.Live.Search
                 Query = new RiakFluentSearch(Index, "name_s").Search(Token.StartsWith(_randomId + "Al")).Build()
             };
 
-            var searchResult = RunSolrQuery(req).WaitUntil(TwoMatchesFound);
+            var searchResult = Client.RunSolrQuery(req).WaitUntil(SearchTestHelpers.TwoMatchesFound);
             searchResult.IsSuccess.ShouldBeTrue(searchResult.ErrorMessage);
             searchResult.Value.NumFound.ShouldEqual(2u);
             searchResult.Value.Documents.Count.ShouldEqual(2);
@@ -142,7 +142,7 @@ namespace CorrugatedIron.Tests.Live.Search
 
             Console.WriteLine(req.Query.ToString());
 
-            var result = RunSolrQuery(req).WaitUntil(AnyMatchIsFound);
+            var result = Client.RunSolrQuery(req).WaitUntil(SearchTestHelpers.AnyMatchIsFound);
 
             result.IsSuccess.ShouldBeTrue(result.ErrorMessage);
             result.Value.NumFound.ShouldEqual(1u);
@@ -181,44 +181,12 @@ namespace CorrugatedIron.Tests.Live.Search
 
             Console.WriteLine(req.Query.ToString());
 
-            var result = RunSolrQuery(req).WaitUntil(AnyMatchIsFound);
+            var result = Client.RunSolrQuery(req).WaitUntil(SearchTestHelpers.AnyMatchIsFound);
             result.IsSuccess.ShouldBeTrue(result.ErrorMessage);
             result.Value.NumFound.ShouldEqual(1u);
             result.Value.Documents.Count.ShouldEqual(1);
             result.Value.Documents[0].Fields.Count.ShouldEqual(3);
             result.Value.Documents[0].Id.ShouldNotBeNull();
-        }
-
-
-        private Func<RiakResult<RiakSearchResult>> RunSolrQuery(RiakSearchRequest req)
-        {
-            Func<RiakResult<RiakSearchResult>> runSolrQuery =
-                () => Client.Search(req);
-            return runSolrQuery;
-        }
-        
-        private static Func<RiakResult<RiakSearchResult>, bool> AnyMatchIsFound
-        {
-            get
-            {
-                Func<RiakResult<RiakSearchResult>, bool> matchIsFound =
-                    result => result.IsSuccess &&
-                              result.Value != null &&
-                              result.Value.NumFound > 0;
-                return matchIsFound;
-            }
-        }
-
-        private static Func<RiakResult<RiakSearchResult>, bool> TwoMatchesFound
-        {
-            get
-            {
-                Func<RiakResult<RiakSearchResult>, bool> twoMatchesFound =
-                    result => result.IsSuccess &&
-                              result.Value != null &&
-                              result.Value.NumFound == 2;
-                return twoMatchesFound;
-            }
         }
     }
 }

--- a/src/CorrugatedIron.Tests.Live/Search/TestSearchOperation.cs
+++ b/src/CorrugatedIron.Tests.Live/Search/TestSearchOperation.cs
@@ -14,6 +14,27 @@ namespace CorrugatedIron.Tests.Live.Search
     [TestFixture]
     public class TestSearchOperation : LiveRiakConnectionTestBase
     {
+        public TestSearchOperation()
+            : base("riak1NodeConfiguration")
+        {
+        }
+
+        private const string BucketType = "search_type";
+        private const string Bucket = "yoko_bucket";
+        private const string Index = "yoko_index";
+        private const string RiakSearchKey = "a.hacker";
+        private const string RiakSearchKey2 = "a.public";
+        private readonly Random _random = new Random();
+        private int _randomId;
+        private RiakObjectId _alyssaRiakId;
+
+        // See https://raw.githubusercontent.com/basho/yokozuna/develop/priv/default_schema.xml for dynamic field suffix meanings.
+        private const string RiakSearchDoc =
+            "{{\"name_s\":\"{0}Alyssa P. Hacker\", \"age_i\":35, \"leader_b\":true, \"bio_tsd\":\"I'm an engineer, making awesome things.\", \"favorites\":{{\"book_tsd\":\"The Moon is a Harsh Mistress\",\"album_tsd\":\"Magical Mystery Tour\" }}}}";
+
+        private const string RiakSearchDoc2 =
+            "{{\"name_s\":\"{0}Alan Q. Public\", \"age_i\":38, \"bio_tsd\":\"I'm an exciting awesome mathematician\", \"favorites\":{{\"book_tsd\":\"Prelude to Mathematics\",\"album_tsd\":\"The Fame Monster\"}}}}";
+
         [TestFixtureSetUp]
         public void Init()
         {
@@ -41,27 +62,11 @@ namespace CorrugatedIron.Tests.Live.Search
             PrepSearch();
         }
 
-        public TestSearchOperation()
-            : base("riak1NodeConfiguration")
+        [TestFixtureTearDown]
+        public void TearDown()
         {
+            Client.DeleteBucket(BucketType, Bucket);
         }
-
-        private const string BucketType = "search_type";
-        private const string Bucket = "yoko_bucket";
-        private const string Index = "yoko_index";
-        private const string RiakSearchKey = "a.hacker";
-        private const string RiakSearchKey2 = "a.public";
-        private readonly Random _random = new Random();
-        private int _randomId;
-        private RiakObjectId _alyssaRiakId;
-
-        // See https://raw.githubusercontent.com/basho/yokozuna/develop/priv/default_schema.xml for dynamic field suffix meanings.
-        private const string RiakSearchDoc =
-            "{{\"name_s\":\"{0}Alyssa P. Hacker\", \"age_i\":35, \"leader_b\":true, \"bio_tsd\":\"I'm an engineer, making awesome things.\", \"favorites\":{{\"book_tsd\":\"The Moon is a Harsh Mistress\",\"album_tsd\":\"Magical Mystery Tour\" }}}}";
-
-        private const string RiakSearchDoc2 =
-            "{{\"name_s\":\"{0}Alan Q. Public\", \"age_i\":38, \"bio_tsd\":\"I'm an exciting awesome mathematician\", \"favorites\":{{\"book_tsd\":\"Prelude to Mathematics\",\"album_tsd\":\"The Fame Monster\"}}}}";
-
 
         private void PrepSearch()
         {

--- a/src/CorrugatedIron/Models/Search/RiakSearchResultDocument.cs
+++ b/src/CorrugatedIron/Models/Search/RiakSearchResultDocument.cs
@@ -44,9 +44,10 @@ namespace CorrugatedIron.Models.Search
         }
 
         public List<RiakSearchResultField> Fields { get; private set; }
-        
+
         internal RiakSearchResultDocument(RpbSearchDoc doc)
         {
+            string legacyId = null;
             Fields = new List<RiakSearchResultField>();
 
             foreach (var field in doc.fields.Select(f => new RiakSearchResultField(f)))
@@ -68,9 +69,22 @@ namespace CorrugatedIron.Models.Search
                     case RiakConstants.SearchFieldKeys.Key:
                         Key = field.Value;
                         break;
+                    case RiakConstants.SearchFieldKeys.LegacySearchId:
+                        legacyId = field.Value;
+                        break;
                 }
                 Fields.Add(field);
             }
+
+            if (CanUseLegacyId(legacyId))
+            {
+                Id = legacyId;
+            }
+        }
+
+        private bool CanUseLegacyId(string legacyId)
+        {
+            return Id == null && legacyId != null;
         }
     }
 }

--- a/src/CorrugatedIron/Util/RiakConstants.cs
+++ b/src/CorrugatedIron/Util/RiakConstants.cs
@@ -174,12 +174,14 @@ namespace CorrugatedIron.Util
 
         public static class SearchFieldKeys
         {
-                public const string BucketType = "_yz_rt";
-                public const string Bucket = "_yz_rb";
-                public const string Key = "_yz_rk";
+            public const string BucketType = "_yz_rt";
+            public const string Bucket = "_yz_rb";
+            public const string Key = "_yz_rk";
 
-                public const string Id = "_yz_id";
-                public const string Score = "score";
+            public const string Id = "_yz_id";
+            public const string Score = "score";
+
+            public const string LegacySearchId = "id";
         }
     }
 }

--- a/tools/legacy-search-conf
+++ b/tools/legacy-search-conf
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+riak_conf=$1
+adv_conf=$2
+
+sed -i -e "s/search = on/search = off/g" $riak_conf
+
+cat > $adv_conf <<'EOT'
+[
+    {riak_kv, [
+        {delete_mode, immediate}
+    ]},
+    {riak_search, [
+        {enabled, true}
+    ]}
+].
+EOT
+

--- a/tools/riak-cluster-config
+++ b/tools/riak-cluster-config
@@ -1,8 +1,8 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 riak_admin=$1
 http_port=$2
-strong_consistency=$3
+strong_consistency="${3:-false}"
 
 $riak_admin bucket-type create plain '{"props":{}}'
 $riak_admin bucket-type create search_type '{"props":{}}'
@@ -22,7 +22,7 @@ $riak_admin bucket-type activate yokozuna
 $riak_admin bucket-type activate leveldb_type
 $riak_admin bucket-type activate memory_type
 
-if [[ "$strong_consistency" = true ]]
+if [[ $strong_consistency == 'true' ]]
 then
   $riak_admin bucket-type create consistent '{"props":{"consistent":true}}'
   $riak_admin bucket-type activate consistent

--- a/tools/riak-cluster-config
+++ b/tools/riak-cluster-config
@@ -2,6 +2,7 @@
 
 riak_admin=$1
 http_port=$2
+strong_consistency=$3
 
 $riak_admin bucket-type create plain '{"props":{}}'
 $riak_admin bucket-type create search_type '{"props":{}}'
@@ -20,6 +21,12 @@ $riak_admin bucket-type activate counters
 $riak_admin bucket-type activate yokozuna
 $riak_admin bucket-type activate leveldb_type
 $riak_admin bucket-type activate memory_type
+
+if [[ "$strong_consistency" = true ]]
+then
+  $riak_admin bucket-type create consistent '{"props":{"consistent":true}}'
+  $riak_admin bucket-type activate consistent
+fi
 
 curl -4 -XPUT -H 'Content-type: application/json' localhost:$http_port/buckets/riak_index_tests/props -d '{"props":{"backend":"leveldb_backend"}}'
 

--- a/tools/setup-dev-cluster
+++ b/tools/setup-dev-cluster
@@ -16,6 +16,12 @@ else
 fi
 PATH="$PATH:$script_path"
 
+default_dev_path=$HOME/Projects/basho/riak/dev
+default_node_count=4
+
+old_search=false
+strong_consistency=false
+
 function make_temp_file
 {
   local template="$1"
@@ -86,17 +92,66 @@ function wait_for_transfers
   done
 }
 
+usage () {
+cat << 'EOF'
+setup-dev-cluster: Quickly setup a dev Riak cluster.
+
+Usage: setup-dev-cluster [-p <riak dev path>] [-l <node count>] [-s] [-c]
+
+-p      Riak dev path, defaults to "$default_dev_path"
+-n      Node count, defaults to "$default_node_count"
+-s      Setup cluster to use Legacy Search instead of Yokozuna Search.
+-c      Setup cluster for Strong Consistency, overrides -n setting.
+
+EOF
+exit
+}
+
+while getopts "sp:n:ch" opt; do
+  case $opt in
+    s)
+      old_search=true;;
+    p)
+      dev_cluster_path=$OPTARG;;
+    n)
+      node_count=$OPTARG;;
+    c)
+      strong_consistency=true;;
+    h)
+      usage;;
+    \?) 
+      exit 1;;
+    :) 
+      exit 1;;
+  esac
+done
+
+if [[ "$strong_consistency" = true ]]
+then
+  node_count=8
+fi
+
 trap onexit EXIT
 
-dev_cluster_path="${1:-$HOME/Projects/basho/riak/dev}"
-declare -i node_count="${2:-4}"
+dev_cluster_path="${dev_cluster_path:-$default_dev_path}"
+declare -i node_count="${node_count:-$default_node_count}"
 declare -i i=0
 
 if [[ -d $dev_cluster_path ]]
 then
-  pinfo "Setting up dev cluster in $dev_cluster_path"
+  pinfo "Setting up dev cluster in $dev_cluster_path with $node_count nodes"
 else
   errexit "Dev cluster path $dev_cluster_path does not exist!"
+fi
+
+if [[ "$old_search" = true ]]
+then
+  pinfo "Setting up dev cluster with Legacy Search"
+fi
+
+if [[ "$strong_consistency" = true ]]
+then
+  pinfo "Setting up dev cluster with Strong Consistency"
 fi
 
 pushd $dev_cluster_path > /dev/null
@@ -144,6 +199,16 @@ do
   gen-riak-conf $riak_conf $http_port $pb_port
   gen-adv-conf $adv_conf
 
+  if [[ "$old_search" = true ]]
+  then
+    legacy-search-conf $riak_conf $adv_conf
+  fi
+
+  if [[ "$strong_consistency" = true ]]
+  then
+    strong-consistency-conf $riak_conf
+  fi
+
   (( pb_port += 10 ))
   (( http_port += 10 ))
 done
@@ -169,6 +234,6 @@ $riak_admin transfer-limit 8
 wait_for_transfers
 
 pinfo "Riak started, setting up bucket types"
-riak-cluster-config "$riak_admin" 10018
+riak-cluster-config "$riak_admin" 10018 $strong_consistency
 pinfo "Done!"
 

--- a/tools/setup-dev-cluster
+++ b/tools/setup-dev-cluster
@@ -16,8 +16,8 @@ else
 fi
 PATH="$PATH:$script_path"
 
-default_dev_path=$HOME/Projects/basho/riak/dev
-default_node_count=4
+default_dev_path="$HOME/Projects/basho/riak/dev"
+declare -i default_node_count=4
 
 old_search=false
 strong_consistency=false
@@ -25,7 +25,7 @@ strong_consistency=false
 function make_temp_file
 {
   local template="$1"
-  if [[ ! $template == *XXXXXX ]]
+  if [[ $template != *XXXXXX ]]
   then
     template="$template.XXXXXX"
   fi
@@ -92,19 +92,20 @@ function wait_for_transfers
   done
 }
 
-usage () {
-cat << 'EOF'
+function usage
+{
+    echo "
 setup-dev-cluster: Quickly setup a dev Riak cluster.
 
 Usage: setup-dev-cluster [-p <riak dev path>] [-l <node count>] [-s] [-c]
 
--p      Riak dev path, defaults to "$default_dev_path"
--n      Node count, defaults to "$default_node_count"
+-p      Riak dev path, defaults to \"$default_dev_path\"
+-n      Node count, defaults to $default_node_count
 -s      Setup cluster to use Legacy Search instead of Yokozuna Search.
--c      Setup cluster for Strong Consistency, overrides -n setting.
-
-EOF
-exit
+-c      Setup cluster for Strong Consistency.
+        Note: overrides -n setting and uses 8 nodes
+"
+    exit 0
 }
 
 while getopts "sp:n:ch" opt; do
@@ -114,27 +115,23 @@ while getopts "sp:n:ch" opt; do
     p)
       dev_cluster_path=$OPTARG;;
     n)
-      node_count=$OPTARG;;
+      opt_node_count=$OPTARG;;
     c)
       strong_consistency=true;;
-    h)
+    *)
       usage;;
-    \?) 
-      exit 1;;
-    :) 
-      exit 1;;
   esac
 done
 
-if [[ "$strong_consistency" = true ]]
+if [[ $strong_consistency == 'true' ]]
 then
-  node_count=8
+  opt_node_count=8
 fi
 
 trap onexit EXIT
 
 dev_cluster_path="${dev_cluster_path:-$default_dev_path}"
-declare -i node_count="${node_count:-$default_node_count}"
+declare -i node_count="${opt_node_count:-$default_node_count}"
 declare -i i=0
 
 if [[ -d $dev_cluster_path ]]
@@ -144,12 +141,12 @@ else
   errexit "Dev cluster path $dev_cluster_path does not exist!"
 fi
 
-if [[ "$old_search" = true ]]
+if [[ $old_search == 'true' ]]
 then
   pinfo "Setting up dev cluster with Legacy Search"
 fi
 
-if [[ "$strong_consistency" = true ]]
+if [[ $strong_consistency == 'true' ]]
 then
   pinfo "Setting up dev cluster with Strong Consistency"
 fi
@@ -199,12 +196,12 @@ do
   gen-riak-conf $riak_conf $http_port $pb_port
   gen-adv-conf $adv_conf
 
-  if [[ "$old_search" = true ]]
+  if [[ $old_search == 'true' ]]
   then
     legacy-search-conf $riak_conf $adv_conf
   fi
 
-  if [[ "$strong_consistency" = true ]]
+  if [[ $strong_consistency == 'true' ]]
   then
     strong-consistency-conf $riak_conf
   fi

--- a/tools/strong-consistency-conf
+++ b/tools/strong-consistency-conf
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+out_file=$1
+
+cat >> $out_file <<'EOT'
+strong_consistency = on
+EOT
+


### PR DESCRIPTION
Starting this PR early.  Adding Legacy Search configuration options to our `setup-dev-cluster` script, as well as a bonus option to configure Strong Consistency. 

Addresses issue #225.

@lukebakken: criticism welcome. 

CLIENTS-116
CLIENTS-117