### PR TITLE
Added Fisher-Yates shuffle load balancing strategy

### DIFF
--- a/src/CorrugatedIron.Tests/Comms/FisherYatesStrategyTests.cs
+++ b/src/CorrugatedIron.Tests/Comms/FisherYatesStrategyTests.cs
@@ -25,11 +25,11 @@ using System.Threading.Tasks;
 
 namespace CorrugatedIron.Tests.Comms.RoundRobinStrategyTests
 {
-    public class RoundRobinStrategyTests : WhenAddingAndRemovingNodesConstantlyOnDifferentThreads
-    {
-        protected override ILoadBalancingStrategy CreateStrategy ()
+	public class FisherYatesStrategyTests : WhenAddingAndRemovingNodesConstantlyOnDifferentThreads
+	{
+		protected override ILoadBalancingStrategy CreateStrategy ()
 		{
-			return new RoundRobinStrategy ();
+			return new FisherYatesStrategy ();
 		}
-    }
+	}
 }

--- a/src/CorrugatedIron.Tests/Comms/LoadBalancingStrategyTests.cs
+++ b/src/CorrugatedIron.Tests/Comms/LoadBalancingStrategyTests.cs
@@ -1,0 +1,123 @@
+﻿// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
+//
+// This file is provided to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file
+// except in compliance with the License.  You may obtain
+// a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+using CorrugatedIron.Comms;
+using CorrugatedIron.Comms.LoadBalancing;
+using Moq;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace CorrugatedIron.Tests.Comms.RoundRobinStrategyTests
+{
+	[TestFixture]
+	public abstract class WhenAddingAndRemovingNodesConstantlyOnDifferentThreads
+	{
+		protected abstract ILoadBalancingStrategy CreateStrategy ();
+
+		[Test]
+		public void NoExceptionsShouldBeThrown()
+		{
+			// three sets for three different threads
+			var nodes = new[] { CreateMockNodes(), CreateMockNodes(), CreateMockNodes() };
+			var strategy = CreateStrategy ();
+
+			strategy.Initialise(nodes.SelectMany(n => n));
+
+			var results = new Exception[3];
+
+			Parallel.For(0, 3, i =>
+				{
+					results[i] = DoStuffWithNodes(strategy, CreateMockNodes());
+				});
+
+			foreach (var result in results)
+			{
+				Assert.IsNull(result);
+			}
+		}
+
+		private static Exception DoStuffWithNodes(ILoadBalancingStrategy strategy, IEnumerable<IRiakNode> nodes)
+		{
+			var rnd = new Random();
+			var availableNodes = new Queue<IRiakNode>(nodes);
+			var unavailableNodes = new Queue<IRiakNode>();
+
+			try
+			{
+				for (var i = 0; i < 1000000; ++i)
+				{
+					switch (rnd.Next(0, 3))
+					{
+					case 1:
+						strategy.SelectNode();
+						break;
+					case 2:
+						if (unavailableNodes.Count > 0)
+						{
+							var node = unavailableNodes.Dequeue();
+							strategy.AddNode(node);
+							availableNodes.Enqueue(node);
+						}
+						else
+						{
+							--i;
+						}
+						break;
+					default:
+						if (availableNodes.Count > 0)
+						{
+							var node = availableNodes.Dequeue();
+							strategy.RemoveNode(node);
+							unavailableNodes.Enqueue(node);
+						}
+						else
+						{
+							--i;
+						}
+						break;
+
+					}
+				}
+
+				while (availableNodes.Count > 0)
+				{
+					strategy.RemoveNode(availableNodes.Dequeue());
+				}
+
+				strategy.SelectNode();
+			}
+			catch (Exception ex)
+			{
+				return ex;
+			}
+
+			return null;
+		}
+
+		private static IEnumerable<IRiakNode> CreateMockNodes()
+		{
+			var nodes = new List<IRiakNode>();
+			for (var i = 0; i < 10; ++i)
+			{
+				nodes.Add(new Mock<IRiakNode>().Object);
+			}
+			return nodes;
+		}
+	}
+}

--- a/src/CorrugatedIron.Tests/CorrugatedIron.Tests.csproj
+++ b/src/CorrugatedIron.Tests/CorrugatedIron.Tests.csproj
@@ -76,6 +76,8 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="KeyFilters\KeyFilterTests.cs" />
     <Compile Include="RiakSearchTests.cs" />
+    <Compile Include="Comms\FisherYatesStrategyTests.cs" />
+    <Compile Include="Comms\LoadBalancingStrategyTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\CorrugatedIron.snk">

--- a/src/CorrugatedIron/Comms/LoadBalancing/FisherYatesStrategy.cs
+++ b/src/CorrugatedIron/Comms/LoadBalancing/FisherYatesStrategy.cs
@@ -1,0 +1,111 @@
+﻿// Copyright (c) 2011 - OJ Reeves & Jeremiah Peschka
+//
+// This file is provided to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file
+// except in compliance with the License.  You may obtain
+// a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+using System.Collections.Generic;
+using CorrugatedIron.Containers;
+using System;
+using System.Linq;
+
+namespace CorrugatedIron.Comms.LoadBalancing
+{
+	public class FisherYatesStrategy : ILoadBalancingStrategy
+	{
+		private readonly Random _random = new Random();
+		private readonly object _nodesLock = new object();
+		private List<IRiakNode> _nodes;
+		private IConcurrentEnumerator<IRiakNode> _roundRobin;
+		private Func<IEnumerable<IRiakNode>> _generator;
+
+		public void Initialise(IEnumerable<IRiakNode> nodes)
+		{
+			_nodes = nodes.ToList();
+			var list = Shuffle (_nodes);
+			_generator = () => list;
+			_roundRobin = new ConcurrentEnumerable<IRiakNode>(RoundRobin()).GetEnumerator();
+		}
+
+		public IRiakNode SelectNode()
+		{
+			IRiakNode node = null;
+			if(_roundRobin.TryMoveNext(out node))
+			{
+				return node;
+			}
+			return null;
+		}
+
+		public void RemoveNode(IRiakNode node)
+		{
+			lock(_nodesLock)
+			{
+				if(_nodes.Contains(node))
+				{
+					_nodes.Remove(node);
+					var list = Shuffle (_nodes);
+					_generator = () => list;
+				}
+			}
+		}
+
+		public void AddNode(IRiakNode node)
+		{
+			lock(_nodesLock)
+			{
+				if(!_nodes.Contains(node))
+				{
+					_nodes.Add(node);
+					var list = Shuffle (_nodes);
+					_generator = () => list;
+				}
+			}
+		}
+
+		private IEnumerable<IRiakNode> RoundRobin()
+		{
+			while(true)
+			{
+				var list = _generator().ToList();
+				if(list.Count > 0)
+				{
+					var nodes = list.GetEnumerator();
+					while(nodes.MoveNext() && nodes.Current != null)
+					{
+						yield return nodes.Current;
+					}
+				}
+				else
+				{
+					yield return null;
+				}
+			}
+		}
+
+		private List<T> Shuffle<T>(IEnumerable<T> source)
+		{
+			var array = source.ToArray ();
+			var n = array.Length;
+			for (var i = 0; i < n; i++)
+			{
+				var r = i + (int)(_random.NextDouble() * (n - i));
+				T t = array[r];
+				array[r] = array[i];
+				array[i] = t;
+			}
+
+			return array.ToList ();
+		}
+	}
+}

--- a/src/CorrugatedIron/CorrugatedIron.csproj
+++ b/src/CorrugatedIron/CorrugatedIron.csproj
@@ -65,6 +65,7 @@
       <Link>Properties\CommonAssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="Comms\IRiakConnectionManager.cs" />
+    <Compile Include="Comms\LoadBalancing\FisherYatesStrategy.cs" />
     <Compile Include="Comms\LoadBalancing\ILoadBalancingStrategy.cs" />
     <Compile Include="Comms\LoadBalancing\RoundRobinStrategy.cs" />
     <Compile Include="Comms\RiakOnTheFlyConnection.cs" />
@@ -294,4 +295,3 @@
     <CallTarget Targets="CleanCommonAssemblyInfo" />
   </Target>
 </Project>
-

--- a/src/CorrugatedIron/RiakCluster.cs
+++ b/src/CorrugatedIron/RiakCluster.cs
@@ -29,7 +29,7 @@ namespace CorrugatedIron
 {
     public class RiakCluster : RiakEndPoint
     {
-        private readonly RoundRobinStrategy _loadBalancer;
+        private readonly ILoadBalancingStrategy _loadBalancer;
         private readonly List<IRiakNode> _nodes;
         private readonly ConcurrentQueue<IRiakNode> _offlineNodes;
         private readonly int _nodePollTime;
@@ -41,11 +41,11 @@ namespace CorrugatedIron
             get { return _defaultRetryCount; }
         }
 
-        public RiakCluster(IRiakClusterConfiguration clusterConfiguration, IRiakConnectionFactory connectionFactory)
+        public RiakCluster(IRiakClusterConfiguration clusterConfiguration, IRiakConnectionFactory connectionFactory, ILoadBalancingStrategy loadBalancingStrategy = null)
         {
             _nodePollTime = clusterConfiguration.NodePollTime;
             _nodes = clusterConfiguration.RiakNodes.Select(rn => new RiakNode(rn, connectionFactory)).Cast<IRiakNode>().ToList();
-            _loadBalancer = new RoundRobinStrategy();
+			_loadBalancer = loadBalancingStrategy ?? new RoundRobinStrategy();
             _loadBalancer.Initialise(_nodes);
             _offlineNodes = new ConcurrentQueue<IRiakNode>();
             _defaultRetryCount = clusterConfiguration.DefaultRetryCount;


### PR DESCRIPTION
Hi

I added a random load balancing strategy (Fisher-Yates) and associated tests.

There is scope for RoundRobin and FisherYates strategies to share a common base, I didn't feel this was worth doing given that the code is fairly trivial, you may disagree.

I refactored the RoundRobin tests to create an abstract base and extended it for FY.

Kind Regards
Myles